### PR TITLE
Fix dynamic library path

### DIFF
--- a/sdk.js
+++ b/sdk.js
@@ -12,8 +12,11 @@ const questionSetPtr = voidPtr;
 const sdkCallback = ffi.Function('void', [voidPtr]);
 const clickerRespondedCallback = ffi.Function('void', ['string', 'string', 'string', voidPtr]);
 
+const path = require('path');
+const libraryPath = path.join(__dirname, 'SMARTResponseSDK-2.0.dll');
+
 const sdk = ffi.Library(
-  'C:\\Program Files (x86)\\SMART Technologies\\SMART Response\\SMARTResponseSDK-2.0',
+  libraryPath,
   {
     smartresponse_sdk_initialize: ['int', ['int']],
     smartresponse_sdk_terminate: ['void', []],


### PR DESCRIPTION
## Summary
- load SMARTResponseSDK DLL from repo directory

## Testing
- `npm test` *(fails: no test specified)*
- `node index.js` *(fails to load SMARTResponseSDK-2.0.dll.so on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ec4b7f0832191f5e6171c57fb5e